### PR TITLE
fix: handle duplicate GitHub releases in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ needs.release.outputs.tag }} \
-            --title "Release ${{ needs.release.outputs.version }}" \
-            --generate-notes \
-            ./dist/*
+          if gh release view ${{ needs.release.outputs.tag }} > /dev/null 2>&1; then
+            echo "Release ${{ needs.release.outputs.tag }} already exists, updating assets..."
+            gh release upload ${{ needs.release.outputs.tag }} ./dist/* --clobber
+          else
+            echo "Creating new release ${{ needs.release.outputs.tag }}..."
+            gh release create ${{ needs.release.outputs.tag }} \
+              --title "Release ${{ needs.release.outputs.version }}" \
+              --generate-notes \
+              ./dist/*
+          fi


### PR DESCRIPTION
## Summary
- Fix workflow failure when trying to create duplicate GitHub releases
- Check if release already exists before attempting to create it
- Update release assets instead of failing on duplicate release

## Problem
The release workflow was failing with "a release with the same tag name already exists" when running multiple times for the same version.

## Solution
- Added conditional logic to check if release exists
- If exists, update assets with `--clobber` flag
- If not exists, create new release as before

## Test plan
- [x] Workflow syntax is valid YAML
- [x] Logic handles both create and update scenarios
- [ ] Test by merging and watching workflow run

🤖 Generated with [Claude Code](https://claude.ai/code)