### PR TITLE
fix: handle exceptions during calibration phase gracefully

### DIFF
--- a/minigun/specify.py
+++ b/minigun/specify.py
@@ -396,10 +396,15 @@ def _run_calibration(spec: Spec) -> bool:
 
                 for total_attempts in range(1, max_calibration_attempts + 1):
                     attempt_start = time.time()
-                    calibration_state, _ = s.find_counter_example(
-                        calibration_state, 1, law, _generators
-                    )
-                    attempt_times.append(time.time() - attempt_start)
+                    try:
+                        calibration_state, _ = s.find_counter_example(
+                            calibration_state, 1, law, _generators
+                        )
+                        attempt_times.append(time.time() - attempt_start)
+                    except Exception:
+                        # Count time until exception as valid calibration sample
+                        attempt_times.append(time.time() - attempt_start)
+                        # Continue calibration to get stable timing estimate
 
                     if total_attempts < min_calibration_attempts:
                         continue

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "minigun-soren-n"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "returns" },


### PR DESCRIPTION
## Summary
- Fixes issue where tests throwing exceptions during calibration would crash the calibration phase
- Exceptions are now caught and the elapsed time is recorded as a valid calibration sample
- Budget allocation proceeds normally and the test properly fails during execution phase

## Changes
- Added try-catch block around `find_counter_example()` in calibration loop
- Time until exception is counted towards average execution time estimate
- Calibration continues to collect more samples for stable timing

## Test plan
- [x] All existing tests pass
- [x] Linting checks pass
- [x] Verified with test that throws exception during calibration - calibration completes and test fails properly during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)