### PR TITLE
fix: convert markdown code blocks to RST in module docstrings

### DIFF
--- a/minigun/arbitrary.py
+++ b/minigun/arbitrary.py
@@ -14,18 +14,17 @@ Key Components:
 The module follows functional programming principles with immutable state and
 pure functions that explicitly thread PRNG state through computations.
 
-Example:
-    ```python
-    import minigun.arbitrary as a
+Example::
 
-    # Initialize state
-    state = a.seed(42)
+        import minigun.arbitrary as a
 
-    # Generate values with explicit state threading
-    state, value1 = a.int(state, 1, 100)
-    state, value2 = a.bool(state)
-    state, chosen = a.choice(state, ["a", "b", "c"])
-    ```
+        # Initialize state
+        state = a.seed(42)
+
+        # Generate values with explicit state threading
+        state, value1 = a.int(state, 1, 100)
+        state, value2 = a.bool(state)
+        state, chosen = a.choice(state, ["a", "b", "c"])
 """
 
 # External module dependencies

--- a/minigun/generate.py
+++ b/minigun/generate.py
@@ -18,22 +18,21 @@ Built-in Generators:
 The generator system integrates with the cardinality analysis system to provide
 optimal test attempt allocation based on domain complexity.
 
-Example:
-    ```python
-    import minigun.generate as g
-    import minigun.arbitrary as a
+Example::
 
-    # Create generators for custom data
-    person_gen = g.map(
-        lambda name, age: {"name": name, "age": age},
-        g.str(),
-        g.nat(0, 120)
-    )
+        import minigun.generate as g
+        import minigun.arbitrary as a
 
-    # Sample values
-    state = a.seed(42)
-    state, maybe_person = person_gen(state)
-    ```
+        # Create generators for custom data
+        person_gen = g.map(
+            lambda name, age: {"name": name, "age": age},
+            g.str(),
+            g.nat(0, 120)
+        )
+
+        # Sample values
+        state = a.seed(42)
+        state, maybe_person = person_gen(state)
 """
 
 # External module dependencies

--- a/minigun/shrink.py
+++ b/minigun/shrink.py
@@ -18,22 +18,21 @@ Built-in Shrinking:
 The shrinking system is integrated with generators to automatically provide
 minimal counterexamples without additional user configuration.
 
-Example:
-    ```python
-    import minigun.shrink as s
-    import minigun.stream as fs
+Example::
 
-    # Define custom trimmer for non-empty lists
-    def trim_nonempty_list(lst: list[int]) -> fs.Stream[list[int]]:
-        if len(lst) <= 1:
-            return fs.empty()
-        # Try removing elements
-        for i in range(len(lst)):
-            yield lst[:i] + lst[i+1:]
+        import minigun.shrink as s
+        import minigun.stream as fs
 
-    # Create dissection with custom shrinking
-    dissection = s.unfold([1, 2, 3, 4], trim_nonempty_list)
-    ```
+        # Define custom trimmer for non-empty lists
+        def trim_nonempty_list(lst: list[int]) -> fs.Stream[list[int]]:
+            if len(lst) <= 1:
+                return fs.empty()
+            # Try removing elements
+            for i in range(len(lst)):
+                yield lst[:i] + lst[i+1:]
+
+        # Create dissection with custom shrinking
+        dissection = s.unfold([1, 2, 3, 4], trim_nonempty_list)
 """
 
 # External module dependencies

--- a/minigun/specify.py
+++ b/minigun/specify.py
@@ -20,23 +20,22 @@ Test Execution Flow:
 The module integrates with the reporter system for sophisticated output
 including cardinality analysis, budget allocation, and performance metrics.
 
-Example:
-    ```python
-    from minigun.specify import prop, context, check, conj
-    import minigun.domain as d
+Example::
 
-    @prop("list length distributes over concatenation")
-    def test_list_length(xs: list[int], ys: list[int]):
-        return len(xs + ys) == len(xs) + len(ys)
+        from minigun.specify import prop, context, check, conj
+        import minigun.domain as d
 
-    @context(d.list(d.int(), 0, 10))
-    @prop("sorted lists remain sorted after append")
-    def test_sorted_append(xs: list[int]):
-        return xs == sorted(xs) if len(xs) <= 1 else True
+        @prop("list length distributes over concatenation")
+        def test_list_length(xs: list[int], ys: list[int]):
+            return len(xs + ys) == len(xs) + len(ys)
 
-    # Run conjunction of tests
-    success = check(conj(test_list_length, test_sorted_append))
-    ```
+        @context(d.list(d.int(), 0, 10))
+        @prop("sorted lists remain sorted after append")
+        def test_sorted_append(xs: list[int]):
+            return xs == sorted(xs) if len(xs) <= 1 else True
+
+        # Run conjunction of tests
+        success = check(conj(test_list_length, test_sorted_append))
 """
 
 # External module dependencies

--- a/minigun/stream.py
+++ b/minigun/stream.py
@@ -15,18 +15,17 @@ Streams enable memory-efficient processing of large or infinite data sets
 while maintaining functional purity and composability. They're particularly
 important in the shrinking system where they represent trees of shrunk values.
 
-Example:
-    ```python
-    import minigun.stream as fs
+Example::
 
-    # Create infinite stream of natural numbers
-    nats = fs.unfold(lambda n: Some((n, n + 1)), 0)
+        import minigun.stream as fs
 
-    # Transform and take first 10 even numbers
-    evens = fs.map(lambda x: x * 2, nats)
-    first_10_evens = fs.to_list(evens, 10)
-    # [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
-    ```
+        # Create infinite stream of natural numbers
+        nats = fs.unfold(lambda n: Some((n, n + 1)), 0)
+
+        # Transform and take first 10 even numbers
+        evens = fs.map(lambda x: x * 2, nats)
+        first_10_evens = fs.to_list(evens, 10)
+        # [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
 """
 
 # External module dependencies


### PR DESCRIPTION
## Summary
- Replace triple-backtick markdown code blocks with RST `::` blocks in 5 module docstrings
- Fixes 27 Sphinx warnings that caused the RTD build to fail (built with `-W` flag)
- Affected modules: `specify`, `generate`, `shrink`, `arbitrary`, `stream`

## Test plan
- [x] Local Sphinx build succeeds with `-W` (warnings as errors)
- [ ] CI passes
- [ ] RTD build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)