### PR TITLE
Audit cleanup: perf fixes, lazy() generator, and misc refactors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Minigun is a property-based testing library organized in 5 architectural layers:
 ### Layer 3: Generation System
 - `generate.py` - Data generators, combinators, and composition (core)
 - `domain.py` - High-level domain specifications
+- `cardinality.py` - Cardinality algebra used by generators and the testing framework to size attempts
 
 ### Layer 4: Testing Framework
 - `specify.py` - Property definition DSL and test execution engine

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a test module in `tests/` directory:
 
 ```python
 # tests/my_tests.py
-from minigun.specify import prop, check, conj
+from minigun import prop, check, conj
 
 @prop("reversing a list twice gives the original")
 def test_reverse(lst: list[int]):
@@ -53,7 +53,7 @@ minigun --time-budget 30
 ## Using as a Library
 
 ```python
-from minigun.specify import prop, check
+from minigun import prop, check
 
 @prop("reversing a list twice gives the original")
 def test_reverse(lst: list[int]):
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 ### Basic Properties
 
 ```python
-from minigun.specify import prop
+from minigun import prop
 
 @prop("addition is commutative")
 def test_add_commute(x: int, y: int):
@@ -142,10 +142,9 @@ def test_add_commute(x: int, y: int):
 ### Custom Domains
 
 ```python
-import minigun.domain as d
-from minigun.specify import prop, context
+from minigun import prop, context, domain as d
 
-@context(d.int(1, 100), d.int(1, 100))
+@context(d.int_range(1, 100), d.int_range(1, 100))
 @prop("division reverses multiplication")
 def test_div(x: int, y: int):
     return (x * y) // y == x
@@ -154,7 +153,7 @@ def test_div(x: int, y: int):
 ### Combining Properties
 
 ```python
-from minigun.specify import prop, check, conj
+from minigun import prop, check, conj
 
 @prop("property 1")
 def test_1(x: int):

--- a/docs/context/DEVELOPMENT_WORKFLOW.md
+++ b/docs/context/DEVELOPMENT_WORKFLOW.md
@@ -29,7 +29,6 @@ pip install -e .[dev,quality]
 ```toml
 dependencies = [
     "returns>=0.25.0",      # Monadic types (Maybe, etc.)
-    "tqdm>=4.67.1",         # Progress bars
     "typeset-soren-n>=2.0.8",  # Type utilities
     "rich>=13.0.0",         # Terminal formatting
 ]
@@ -39,7 +38,7 @@ dependencies = [
 ```toml
 [dependency-groups]
 dev = [
-    "mypy>=1.15.0",         # Static type checking
+    "mypy>=1.18.0",         # Static type checking
     "sphinx>=8.2.3",        # Documentation generation
     "sphinx-rtd-theme>=3.0.2",  # Documentation theme
 ]

--- a/docs/context/GENERATOR_SYSTEM.md
+++ b/docs/context/GENERATOR_SYSTEM.md
@@ -189,6 +189,29 @@ def filter[T](predicate: Callable[[T], bool], generator: Generator[T]) -> Genera
 
 **Important:** May fail if no generated values satisfy predicate. Use sparingly and with predicates that have high success rates.
 
+### 4. Lazy Combinator
+**Purpose:** Defer construction of a generator until the first sample is drawn — required for recursive generator definitions where eager composition of `map`, `bind`, `choice`, etc. would produce exponential construction-time blowup in the recursion depth.
+
+```python
+def lazy[T](thunk: Callable[[], Generator[T]]) -> Generator[T]:
+    cached: list[Generator[T]] = []
+
+    def _impl(state: a.State) -> Sample[T]:
+        if not cached:
+            cached.append(thunk())
+        sampler, _ = cached[0]
+        return sampler(state)
+
+    return _impl, c.Infinite()
+```
+
+**Key Features:**
+- **Deferred construction** — `thunk()` is not called during generator assembly, only on the first sample.
+- **Memoized** — the inner generator is built once and then reused for every subsequent sample.
+- **Infinite cardinality** — reported as `c.Infinite()` since the inner generator is unknown at construction; downstream combinators that see this value fall back to their infinite-cardinality strategies.
+
+**When to use:** Type-directed or recursive generators (e.g., expression trees, grammars) where the full generator graph is larger than the samples you actually draw.
+
 ## Collection Generator Internals
 
 ### Bounded List Generator
@@ -280,7 +303,8 @@ def test_string_repeat(n: int, s: str) -> bool:
 ## Performance Considerations
 
 ### Generator Composition Overhead
-- **Deep composition** can create performance bottlenecks
+- **Deep composition** can create performance bottlenecks; use `g.lazy(thunk)` to break eager cardinality arithmetic in recursive definitions
+- **Signature introspection** in `map`/`bind` is cached per callable identity (`functools.cache` on `_arity_info`), so repeated construction of the same combinator is cheap
 - **Early failure** propagation minimizes wasted computation
 - **Stream laziness** prevents memory issues with large collections
 

--- a/docs/context/PROJECT_OVERVIEW.md
+++ b/docs/context/PROJECT_OVERVIEW.md
@@ -131,7 +131,6 @@ Catch subtle bugs that example-based tests might miss:
 
 **Core Runtime:**
 - `returns` - Monadic types (Maybe, etc.)
-- `tqdm` - Progress bars
 - `typeset-soren-n` - Type utilities
 - `rich` - Terminal formatting
 

--- a/minigun/__init__.py
+++ b/minigun/__init__.py
@@ -1,1 +1,18 @@
+from minigun import domain, generate
+from minigun.specify import Spec, check, conj, context, disj, impl, neg, prop
+
 __version__ = "2.4.3"
+
+__all__ = [
+    "Spec",
+    "__version__",
+    "check",
+    "conj",
+    "context",
+    "disj",
+    "domain",
+    "generate",
+    "impl",
+    "neg",
+    "prop",
+]

--- a/minigun/cardinality.py
+++ b/minigun/cardinality.py
@@ -43,27 +43,27 @@ class _SymbolicExpr(ABC):
     def variables(self) -> set[str]:
         pass
 
-    def __add__(self, other):
+    def __add__(self, other: "_SymbolicExpr | int | float") -> "_SymbolicExpr":
         if isinstance(other, int | float):
             other = _Const(float(other))
         return _Add(self, other).simplify()
 
-    def __mul__(self, other):
+    def __mul__(self, other: "_SymbolicExpr | int | float") -> "_SymbolicExpr":
         if isinstance(other, int | float):
             other = _Const(float(other))
         return _Mul(self, other).simplify()
 
-    def __pow__(self, other):
+    def __pow__(self, other: "_SymbolicExpr | int | float") -> "_SymbolicExpr":
         if isinstance(other, int | float):
             other = _Const(float(other))
         return _Pow(self, other).simplify()
 
-    def __radd__(self, other):
+    def __radd__(self, other: "_SymbolicExpr | int | float") -> "_SymbolicExpr":
         if isinstance(other, int | float):
             return _Const(float(other)) + self
         return NotImplemented
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: "_SymbolicExpr | int | float") -> "_SymbolicExpr":
         if isinstance(other, int | float):
             return _Const(float(other)) * self
         return NotImplemented
@@ -302,7 +302,9 @@ class _Log(_SymbolicExpr):
 class Cardinality(ABC):
     """Abstract base class for cardinality expressions."""
 
-    def __init__(self):
+    _symbolic: "_SymbolicExpr | None"
+
+    def __init__(self) -> None:
         object.__setattr__(self, "_symbolic", None)
 
     @abstractmethod
@@ -324,6 +326,7 @@ class Cardinality(ABC):
         """Convert to internal symbolic representation."""
         if self._symbolic is None:
             object.__setattr__(self, "_symbolic", self._create_symbolic())
+        assert self._symbolic is not None
         return self._symbolic
 
     @abstractmethod
@@ -372,7 +375,7 @@ class Finite(Cardinality):
 
     value: int
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -394,7 +397,7 @@ class Variable(Cardinality):
 
     name: str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -419,7 +422,7 @@ class Sum(Cardinality):
     left: Cardinality
     right: Cardinality
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -459,7 +462,7 @@ class Product(Cardinality):
     left: Cardinality
     right: Cardinality
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -506,7 +509,7 @@ class Exponential(Cardinality):
     base: Cardinality
     exponent: Cardinality
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -552,7 +555,7 @@ class Exponential(Cardinality):
 class Infinite(Cardinality):
     """Infinite cardinality: |S| = ∞"""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
 
     def __str__(self) -> str:
@@ -573,10 +576,9 @@ class Linear(Cardinality):
     """Linear cardinality: |S| = O(n)"""
 
     variable: Variable
-    coefficient: Cardinality
+    coefficient: Cardinality | None = None
 
-    def __post_init__(self):
-        super().__init__()
+    def __post_init__(self) -> None:
         if self.coefficient is None:
             object.__setattr__(self, "coefficient", Finite(1))
 
@@ -586,16 +588,21 @@ class Linear(Cardinality):
         return f"O({self.coefficient} × {self.variable.name})"
 
     def evaluate(self, context: dict[str, int] | None = None) -> float:
-        coeff = self.coefficient.evaluate(context)
+        coeff = self.coefficient.evaluate(context) if self.coefficient else 1.0
         var_val = self.variable.evaluate(context)
         return coeff * var_val
 
     def simplify(self) -> "Cardinality":
-        simplified_coeff = self.coefficient.simplify()
+        simplified_coeff = (
+            self.coefficient.simplify() if self.coefficient else Finite(1)
+        )
         return Linear(self.variable, simplified_coeff)
 
     def _create_symbolic(self) -> _SymbolicExpr:
-        return self.coefficient._to_symbolic() * self.variable._to_symbolic()
+        coeff_sym = (
+            self.coefficient._to_symbolic() if self.coefficient else _Const(1.0)
+        )
+        return coeff_sym * self.variable._to_symbolic()
 
 
 @dataclass(frozen=True)
@@ -606,7 +613,7 @@ class Polynomial(Cardinality):
     degree: int
     coefficient: Cardinality | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
         if self.coefficient is None:
             object.__setattr__(self, "coefficient", Finite(1))
@@ -648,7 +655,7 @@ class Logarithmic(Cardinality):
     variable: Variable
     coefficient: Cardinality | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
         if self.coefficient is None:
             object.__setattr__(self, "coefficient", Finite(1))
@@ -696,7 +703,7 @@ class SymbolicCardinality(Cardinality):
 
     symbolic_expr: _SymbolicExpr
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
         object.__setattr__(self, "_symbolic", self.symbolic_expr)
 
@@ -801,7 +808,7 @@ def calculate_attempts_from_generators(
         return 100
 
     # Extract cardinalities and calculate product
-    total_cardinality = ONE
+    total_cardinality: Cardinality = ONE
     for _param, maybe_generator in generators.items():
         if maybe_generator is not None:
             # Handle Maybe[Generator] case
@@ -855,15 +862,15 @@ def infer_cardinality_from_type(type_hint: Any) -> Cardinality:
 
         elif origin is dict:
             if len(args) >= 2:
-                key_card = infer_cardinality_from_type(args[0])
-                val_card = infer_cardinality_from_type(args[1])
+                key_card = infer_cardinality_from_type(args[0])  # type: ignore[misc]
+                val_card = infer_cardinality_from_type(args[1])  # type: ignore[misc]
                 combined = (key_card * val_card)._to_symbolic()
                 return BigO(combined ** _Var("n"))
             return BigO(_Const(256) ** _Var("n"))
 
         elif origin is tuple:
             if args:
-                product = ONE
+                product: Cardinality = ONE
                 for arg in args:
                     element_card = infer_cardinality_from_type(arg)
                     product = product * element_card

--- a/minigun/cli.py
+++ b/minigun/cli.py
@@ -7,10 +7,13 @@ import argparse
 import importlib.util
 import inspect
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 
-def discover_test_modules(test_dir: Path) -> dict[str, callable]:
+def discover_test_modules(
+    test_dir: Path,
+) -> dict[str, Callable[[], bool]]:
     """
     Discover test modules in a directory.
 
@@ -19,7 +22,7 @@ def discover_test_modules(test_dir: Path) -> dict[str, callable]:
     :param test_dir: Directory to search for test modules
     :return: Dictionary mapping module names to test functions
     """
-    test_modules = {}
+    test_modules: dict[str, Callable[[], bool]] = {}
 
     if not test_dir.exists() or not test_dir.is_dir():
         return test_modules
@@ -86,7 +89,7 @@ def run_tests(
 
     # Filter modules if specified
     if modules:
-        filtered_modules = {}
+        filtered_modules: dict[str, Callable[[], bool]] = {}
         for module in modules:
             if module in test_modules:
                 filtered_modules[module] = test_modules[module]
@@ -118,7 +121,7 @@ def run_tests(
     return orchestrator.execute_tests(test_module_objects)
 
 
-def main():
+def main() -> None:
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         description="Minigun Property-Based Testing CLI - Discovers and runs test modules",

--- a/minigun/generate.py
+++ b/minigun/generate.py
@@ -51,7 +51,7 @@ from builtins import set as _set
 from builtins import str as _str
 from builtins import tuple as _tuple
 from collections.abc import Callable
-from functools import partial
+from functools import cache, partial
 from inspect import Parameter, signature
 from typing import Any, cast, get_args, get_origin
 
@@ -84,6 +84,19 @@ type Generator[T] = _tuple[Sampler[T], c.Cardinality]
 ###############################################################################
 
 
+@cache
+def _arity_info(func: Callable[..., Any]) -> _tuple[_int, _bool]:
+    """Return (argument_count, is_variadic) for func, cached by identity."""
+    try:
+        parameters = signature(func).parameters
+    except (TypeError, ValueError):
+        return 0, True
+    return (
+        len(parameters),
+        any(p.kind == Parameter.VAR_POSITIONAL for p in parameters.values()),
+    )
+
+
 def map[*P, R](
     func: Callable[[*P], R], *generators: Generator[Any]
 ) -> Generator[R]:
@@ -98,12 +111,7 @@ def map[*P, R](
     :rtype: `Generator[R]`
     """
 
-    func_parameters = signature(func).parameters
-    argument_count = len(func_parameters)
-    func_is_variadic = any(
-        parameter.kind == Parameter.VAR_POSITIONAL
-        for parameter in func_parameters.values()
-    )
+    argument_count, func_is_variadic = _arity_info(func)
     assert len(generators) == argument_count or func_is_variadic, (
         f"Function {func} expected {argument_count} "
         f"arguments, but got {len(generators)} generators."
@@ -147,12 +155,7 @@ def bind[*P, R](
     :rtype: `Generator[R]`
     """
 
-    func_parameters = signature(func).parameters
-    argument_count = len(func_parameters)
-    func_is_variadic = any(
-        parameter.kind == Parameter.VAR_POSITIONAL
-        for parameter in func_parameters.values()
-    )
+    argument_count, func_is_variadic = _arity_info(func)
     assert len(generators) == argument_count or func_is_variadic, (
         f"Function {func} expected {argument_count} "
         f"arguments, but got {len(generators)} generators."

--- a/minigun/generate.py
+++ b/minigun/generate.py
@@ -471,6 +471,20 @@ def prop(bias: _float) -> Generator[_bool]:
 ###############################################################################
 # Strings
 ###############################################################################
+@cache
+def _bounded_str_cardinality(
+    lower_bound: _int, upper_bound: _int, alphabet_size: _int
+) -> c.Cardinality:
+    """Cardinality for bounded strings: sum of |alphabet|^l for l in [lo, hi]."""
+    string_cardinality: c.Cardinality = c.Finite(0)
+    alphabet_card = c.Finite(alphabet_size)
+    for length in range(lower_bound, upper_bound + 1):
+        string_cardinality = string_cardinality + (
+            alphabet_card ** c.Finite(length)
+        )
+    return string_cardinality
+
+
 def bounded_str(
     lower_bound: _int, upper_bound: _int, alphabet: _str
 ) -> Generator[_str]:
@@ -497,15 +511,9 @@ def bounded_str(
             result += alphabet[index]
         return state, Some(s.str()(result))
 
-    # Cardinality for bounded strings: sum over all possible lengths
-    # For each length l in [lower_bound, upper_bound], there are |alphabet|^l strings
-    string_cardinality = c.Finite(0)
-    for length in range(lower_bound, upper_bound + 1):
-        string_cardinality = string_cardinality + (
-            c.Finite(len(alphabet)) ** c.Finite(length)
-        )
-
-    return _impl, string_cardinality
+    return _impl, _bounded_str_cardinality(
+        lower_bound, upper_bound, len(alphabet)
+    )
 
 
 def str() -> Generator[_str]:

--- a/minigun/generate.py
+++ b/minigun/generate.py
@@ -183,6 +183,36 @@ def bind[*P, R](
     return _impl, combined_cardinality
 
 
+def lazy[T](thunk: Callable[[], Generator[T]]) -> Generator[T]:
+    """Defer construction of a generator until the first sample is drawn.
+
+    Useful for recursive generator definitions where eager construction
+    (including ``inspect.signature`` calls and cardinality arithmetic
+    performed by combinators such as ``map``, ``bind`` and ``choice``)
+    would otherwise blow up construction time exponentially in the
+    recursion depth. The inner generator is built once and then reused.
+
+    Cardinality is reported as ``Infinite`` since the inner generator
+    is unknown at construction time; combinators that see this value
+    fall back to their infinite-cardinality strategies.
+
+    :param thunk: A zero-argument callable returning a generator of type `T`.
+    :type thunk: `() -> Generator[T]`
+
+    :return: A generator of type `T` that builds its inner generator on demand.
+    :rtype: `Generator[T]`
+    """
+    cached: _list[Generator[T]] = []
+
+    def _impl(state: a.State) -> Sample[T]:
+        if not cached:
+            cached.append(thunk())
+        sampler, _ = cached[0]
+        return sampler(state)
+
+    return _impl, c.Infinite()
+
+
 def filter[T](
     predicate: Callable[[T], _bool], generator: Generator[T]
 ) -> Generator[T]:

--- a/minigun/generate.py
+++ b/minigun/generate.py
@@ -487,8 +487,9 @@ def bounded_str(
     assert lower_bound <= upper_bound
 
     def _impl(state: a.State) -> Sample[_str]:
+        state, length = a.int(state, lower_bound, upper_bound)
         result = ""
-        for _ in range(upper_bound - lower_bound):
+        for _ in range(length):
             state, index = a.int(state, 0, len(alphabet) - 1)
             result += alphabet[index]
         return state, Some(s.str()(result))

--- a/minigun/orchestrator.py
+++ b/minigun/orchestrator.py
@@ -17,6 +17,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from minigun.reporter import JSONReporter, TestReporter, set_reporter
+
 
 @dataclass
 class TestModule:
@@ -85,8 +87,6 @@ class TestOrchestrator:
 
     def _execute_verbose_mode(self, modules: list[TestModule]) -> bool:
         """Execute tests in verbose mode with rich output and two-phase process."""
-        from minigun.reporter import TestReporter, set_reporter
-
         reporter = TestReporter(self.config.time_budget, verbose=True)
         set_reporter(reporter)
         reporter.start_testing(len(modules))
@@ -104,8 +104,6 @@ class TestOrchestrator:
 
     def _execute_json_mode(self, modules: list[TestModule]) -> bool:
         """Execute tests in JSON mode with structured output."""
-        from minigun.reporter import JSONReporter, set_reporter
-
         module_names = [module.name for module in modules]
         reporter = JSONReporter(self.config.time_budget, modules=module_names)
         set_reporter(reporter)

--- a/minigun/reporter.py
+++ b/minigun/reporter.py
@@ -149,7 +149,9 @@ class TestReporter:
         self.module_results: list[ModuleResult] = []
         self.current_module: ModuleResult | None = None
         self.overall_start_time = time.time()
-        self.execution_start_time = None  # Track when execution phase starts
+        self.execution_start_time: float | None = (
+            None  # Track when execution phase starts
+        )
         self.pure_test_execution_time = (
             0.0  # Track only actual property testing time, excluding overhead
         )
@@ -164,7 +166,7 @@ class TestReporter:
         self.modules_processed = 0  # Track number of modules processed
         self.total_modules = 0  # Total number of modules to process
 
-    def start_testing(self, total_modules: int):
+    def start_testing(self, total_modules: int) -> None:
         """Start the overall testing process."""
         self.total_modules = total_modules  # Store total number of modules
         title = f"[bold blue]Minigun Property-Based Testing[/bold blue]\n[dim]Time Budget: {self.time_budget:.1f}s[/dim]"
@@ -405,9 +407,6 @@ class TestReporter:
 
         self.global_execution_started = True
 
-        # Start execution timing here
-        self.execution_start_time = time.time()
-
     def print_cardinality_analysis(self) -> None:
         """Print cardinality analysis table for all tests."""
         # Collect all tests with cardinality info
@@ -442,6 +441,7 @@ class TestReporter:
         total_time = 0.0
         for _module_name, test in cardinality_tests:
             info = test.cardinality_info
+            assert info is not None  # filtered above
 
             # Truncate property name if too long (max 30 chars with ellipsis)
             property_name = self._truncate_property_name(test.name)

--- a/minigun/shrink.py
+++ b/minigun/shrink.py
@@ -48,7 +48,7 @@ from builtins import str as _str
 from builtins import tuple as _tuple
 from collections.abc import Callable
 from inspect import Parameter, signature
-from typing import Any, cast
+from typing import Any
 
 from returns.maybe import Maybe, Nothing, Some
 
@@ -60,7 +60,10 @@ from minigun import stream as fs
 ###############################################################################
 
 #: Dissection datatype defined over a type parameter `T`.
-type Dissection[T] = _tuple[T, fs.Stream["Dissection[T]"]]
+# NOTE: mypy 1.20 has a known internal error on recursive PEP-695 type
+# aliases (https://github.com/python/mypy/issues/18083). Cascading
+# false-positives in this file stem from this limitation.
+type Dissection[T] = _tuple[T, fs.Stream["Dissection[T]"]]  # type: ignore[misc]
 
 #: Shrinker datatype defined over a type parameter `T.
 type Shrinker[T] = Callable[[T], Dissection[T]]
@@ -75,7 +78,7 @@ def head[T](dissection: Dissection[T]) -> T:
     :return: The head of given dissection.
     :rtype: `T`
     """
-    return dissection[0]
+    return dissection[0]  # type: ignore[no-any-return]
 
 
 def tail[T](dissection: Dissection[T]) -> fs.Stream[Dissection[T]]:
@@ -87,7 +90,7 @@ def tail[T](dissection: Dissection[T]) -> fs.Stream[Dissection[T]]:
     :return: The tail of given dissection.
     :rtype: `minigun.stream.Stream[Dissection[T]]`
     """
-    return dissection[1]
+    return dissection[1]  # type: ignore[no-any-return]
 
 
 def map[*Ts, R](
@@ -116,7 +119,9 @@ def map[*Ts, R](
     )
 
     def _combine(input_dissections: list[Dissection[Any]]) -> Dissection[R]:
-        output_heads = [head(dissection) for dissection in input_dissections]
+        output_heads: list[Any] = [
+            head(dissection) for dissection in input_dissections
+        ]
         return func(*output_heads), _cartesian(input_dissections)
 
     def _cartesian(
@@ -172,7 +177,9 @@ def bind[*Ts, R](
     )
 
     def _combine(input_dissections: list[Dissection[Any]]) -> Dissection[R]:
-        output_heads = [head(dissection) for dissection in input_dissections]
+        output_heads: list[Any] = [
+            head(dissection) for dissection in input_dissections
+        ]
         output_head, output_tail = func(*output_heads)
         return output_head, fs.concat(
             output_tail, _cartesian(input_dissections)
@@ -276,7 +283,7 @@ def singleton[T](value: T) -> Dissection[T]:
     :return: A dissection over the type `T`.
     :rtype: `Dissection[T]`
     """
-    return value, cast(fs.Stream[Dissection[T]], fs.empty())
+    return value, fs.empty()
 
 
 ###############################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "returns>=0.25.0",
-    "tqdm>=4.67.1",
     "typeset-soren-n>=2.0.8",
     "rich>=13.0.0",
 ]
@@ -35,7 +34,7 @@ Documentation = "https://minigun.readthedocs.io/en/stable/"
 
 [dependency-groups]
 dev = [
-    "mypy>=1.15.0",
+    "mypy>=1.18.0",
     "sphinx>=8.2.3",
     "sphinx-rtd-theme>=3.0.2",
 ]

--- a/tests/additional.py
+++ b/tests/additional.py
@@ -162,6 +162,34 @@ def test_word_generator_validity(seed_val: int) -> bool:
     return False
 
 
+@context(d.small_nat())
+@prop("lazy defers inner construction and reuses the built generator")
+def test_lazy_generator_defers_and_memoizes(seed_val: int) -> bool:
+    build_count = [0]
+
+    def _build():
+        build_count[0] += 1
+        return g.int_range(1, 10)
+
+    lazy_gen = g.lazy(_build)
+    sampler, cardinality = lazy_gen
+
+    if not isinstance(cardinality, c.Infinite):
+        return False
+    if build_count[0] != 0:
+        return False
+
+    state = a.seed(seed_val)
+    for _ in range(3):
+        state, maybe_result = sampler(state)
+        if isinstance(maybe_result, Some):
+            value = sh.head(maybe_result.unwrap())
+            if not (isinstance(value, int) and 1 <= value <= 10):
+                return False
+
+    return build_count[0] == 1
+
+
 ###############################################################################
 # Additional tests for pretty.py - testing output formatting
 ###############################################################################
@@ -837,6 +865,7 @@ def test() -> bool:
             test_one_of_generator,
             test_str_generator_validity,
             test_word_generator_validity,
+            test_lazy_generator_defers_and_memoizes,
             # Pretty module tests
             test_int_printer,
             test_str_printer,

--- a/tests/additional.py
+++ b/tests/additional.py
@@ -2,6 +2,8 @@
 # Focusing on edge cases, error conditions, and advanced functionality
 
 # External imports
+import contextlib
+import io
 import string
 
 from returns.maybe import Maybe, Some
@@ -681,7 +683,10 @@ def test_orchestrator_execute_simple_modules(seed_val: int) -> bool:
         o.TestModule("sometimes_pass", sometimes_pass),
     ]
 
-    result = orchestrator.execute_tests(modules)
+    # Suppress the orchestrator's own quiet-mode output so it doesn't
+    # interleave with the parent test runner's output.
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = orchestrator.execute_tests(modules)
 
     # Result should be boolean
     return isinstance(result, bool)

--- a/tests/comprehensive.py
+++ b/tests/comprehensive.py
@@ -178,6 +178,43 @@ def test_choice_selection(seed_val: int) -> bool:
             return True  # Empty generation is valid
 
 
+@context(d.small_nat(), d.int_range(0, 8), d.int_range(0, 8))
+@prop("bounded_str respects length bounds")
+def test_bounded_str_bounds(seed_val: int, lower: int, upper: int) -> bool:
+    if lower > upper:
+        return True  # skip invalid
+    state = a.seed(seed_val)
+    sampler, _ = g.bounded_str(lower, upper, "abc")
+    state, maybe = sampler(state)
+    match maybe:
+        case Some(dissection):
+            value = sh.head(dissection)
+            return (
+                isinstance(value, str)
+                and lower <= len(value) <= upper
+                and all(ch in "abc" for ch in value)
+            )
+        case Maybe.empty:
+            return True
+
+
+@prop("bounded_str covers its full length range")
+def test_bounded_str_length_coverage() -> bool:
+    # Regression test: bounded_str previously always emitted
+    # fixed-length strings (upper-lower), never varying across the range.
+    state = a.seed(0xC0FFEE)
+    sampler, _ = g.bounded_str(3, 7, "ab")
+    observed: set[int] = set()
+    for _ in range(400):
+        state, maybe = sampler(state)
+        match maybe:
+            case Some(dissection):
+                observed.add(len(sh.head(dissection)))
+            case Maybe.empty:
+                continue
+    return observed == {3, 4, 5, 6, 7}
+
+
 @context(d.small_nat(), d.int_range(1, 5))
 @prop("list generator produces lists of correct size range")
 def test_list_size(seed_val: int, max_size: int) -> bool:
@@ -555,6 +592,8 @@ def test() -> bool:
             test_map_associative,
             test_filter_predicate,
             test_choice_selection,
+            test_bounded_str_bounds,
+            test_bounded_str_length_coverage,
             test_list_size,
             test_dict_size,
             test_set_size,

--- a/uv.lock
+++ b/uv.lock
@@ -213,6 +213,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -278,7 +338,6 @@ source = { editable = "." }
 dependencies = [
     { name = "returns" },
     { name = "rich" },
-    { name = "tqdm" },
     { name = "typeset-soren-n" },
 ]
 
@@ -298,13 +357,12 @@ quality = [
 requires-dist = [
     { name = "returns", specifier = ">=0.25.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "typeset-soren-n", specifier = ">=2.0.8" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "mypy", specifier = ">=1.18.0" },
     { name = "sphinx", specifier = ">=8.2.3" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
@@ -316,28 +374,45 @@ quality = [
 
 [[package]]
 name = "mypy"
-version = "1.17.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/034322d5a779685218ed69286c32faa505247f1f096251ef66c8fd203b08/mypy-1.17.0.tar.gz", hash = "sha256:e5d7ccc08ba089c06e2f5629c660388ef1fee708444f1dee0b9203fa031dee03", size = 3352114, upload-time = "2025-07-14T20:34:30.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/e9/e6824ed620bbf51d3bf4d6cbbe4953e83eaf31a448d1b3cfb3620ccb641c/mypy-1.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f986f1cab8dbec39ba6e0eaa42d4d3ac6686516a5d3dccd64be095db05ebc6bb", size = 11086395, upload-time = "2025-07-14T20:34:11.452Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/51/a4afd1ae279707953be175d303f04a5a7bd7e28dc62463ad29c1c857927e/mypy-1.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:51e455a54d199dd6e931cd7ea987d061c2afbaf0960f7f66deef47c90d1b304d", size = 10120052, upload-time = "2025-07-14T20:33:09.897Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/71/19adfeac926ba8205f1d1466d0d360d07b46486bf64360c54cb5a2bd86a8/mypy-1.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3204d773bab5ff4ebbd1f8efa11b498027cd57017c003ae970f310e5b96be8d8", size = 11861806, upload-time = "2025-07-14T20:32:16.028Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/64/d6120eca3835baf7179e6797a0b61d6c47e0bc2324b1f6819d8428d5b9ba/mypy-1.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1051df7ec0886fa246a530ae917c473491e9a0ba6938cfd0ec2abc1076495c3e", size = 12744371, upload-time = "2025-07-14T20:33:33.503Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/dc/56f53b5255a166f5bd0f137eed960e5065f2744509dfe69474ff0ba772a5/mypy-1.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f773c6d14dcc108a5b141b4456b0871df638eb411a89cd1c0c001fc4a9d08fc8", size = 12914558, upload-time = "2025-07-14T20:33:56.961Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ac/070bad311171badc9add2910e7f89271695a25c136de24bbafc7eded56d5/mypy-1.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:1619a485fd0e9c959b943c7b519ed26b712de3002d7de43154a489a2d0fd817d", size = 9585447, upload-time = "2025-07-14T20:32:20.594Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7b/5f8ab461369b9e62157072156935cec9d272196556bdc7c2ff5f4c7c0f9b/mypy-1.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c41aa59211e49d717d92b3bb1238c06d387c9325d3122085113c79118bebb06", size = 11070019, upload-time = "2025-07-14T20:32:07.99Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f8/c49c9e5a2ac0badcc54beb24e774d2499748302c9568f7f09e8730e953fa/mypy-1.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0e69db1fb65b3114f98c753e3930a00514f5b68794ba80590eb02090d54a5d4a", size = 10114457, upload-time = "2025-07-14T20:33:47.285Z" },
-    { url = "https://files.pythonhosted.org/packages/89/0c/fb3f9c939ad9beed3e328008b3fb90b20fda2cddc0f7e4c20dbefefc3b33/mypy-1.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03ba330b76710f83d6ac500053f7727270b6b8553b0423348ffb3af6f2f7b889", size = 11857838, upload-time = "2025-07-14T20:33:14.462Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/66/85607ab5137d65e4f54d9797b77d5a038ef34f714929cf8ad30b03f628df/mypy-1.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:037bc0f0b124ce46bfde955c647f3e395c6174476a968c0f22c95a8d2f589bba", size = 12731358, upload-time = "2025-07-14T20:32:25.579Z" },
-    { url = "https://files.pythonhosted.org/packages/73/d0/341dbbfb35ce53d01f8f2969facbb66486cee9804048bf6c01b048127501/mypy-1.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c38876106cb6132259683632b287238858bd58de267d80defb6f418e9ee50658", size = 12917480, upload-time = "2025-07-14T20:34:21.868Z" },
-    { url = "https://files.pythonhosted.org/packages/64/63/70c8b7dbfc520089ac48d01367a97e8acd734f65bd07813081f508a8c94c/mypy-1.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:d30ba01c0f151998f367506fab31c2ac4527e6a7b2690107c7a7f9e3cb419a9c", size = 9589666, upload-time = "2025-07-14T20:34:16.841Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/fc/ee058cc4316f219078464555873e99d170bde1d9569abd833300dbeb484a/mypy-1.17.0-py3-none-any.whl", hash = "sha256:15d9d0018237ab058e5de3d8fce61b6fa72cc59cc78fd91f1b474bce12abf496", size = 2283195, upload-time = "2025-07-14T20:31:54.753Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1b/75a7c825a02781ca10bc2f2f12fba2af5202f6d6005aad8d2d1f264d8d78/mypy-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36ee2b9c6599c230fea89bbd79f401f9f9f8e9fcf0c777827789b19b7da90f51", size = 14494077, upload-time = "2026-04-13T02:45:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/54/5e5a569ea5c2b4d48b729fb32aa936eeb4246e4fc3e6f5b3d36a2dfbefb9/mypy-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fba3fb0968a7b48806b0c90f38d39296f10766885a94c83bd21399de1e14eb28", size = 13319495, upload-time = "2026-04-13T02:45:29.674Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a4/a1945b19f33e91721b59deee3abb484f2fa5922adc33bb166daf5325d76d/mypy-1.20.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef1415a637cd3627d6304dfbeddbadd21079dafc2a8a753c477ce4fc0c2af54f", size = 13696948, upload-time = "2026-04-13T02:46:15.006Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/75e969781c2359b2f9c15b061f28ec6d67c8b61865ceda176e85c8e7f2de/mypy-1.20.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef3461b1ad5cd446e540016e90b5984657edda39f982f4cc45ca317b628f5a37", size = 14706744, upload-time = "2026-04-13T02:46:00.482Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6e/b221b1de981fc4262fe3e0bf9ec272d292dfe42394a689c2d49765c144c4/mypy-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:542dd63c9e1339b6092eb25bd515f3a32a1453aee8c9521d2ddb17dacd840237", size = 14949035, upload-time = "2026-04-13T02:45:06.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4b/298ba2de0aafc0da3ff2288da06884aae7ba6489bc247c933f87847c41b3/mypy-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d55c7cd8ca22e31f93af2a01160a9e95465b5878de23dba7e48116052f20a8d", size = 10883216, upload-time = "2026-04-13T02:45:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f9/5e25b8f0b8cb92f080bfed9c21d3279b2a0b6a601cdca369a039ba84789d/mypy-1.20.1-cp312-cp312-win_arm64.whl", hash = "sha256:f5b84a79070586e0d353ee07b719d9d0a4aa7c8ee90c0ea97747e98cbe193019", size = 9814299, upload-time = "2026-04-13T02:45:21.934Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e8/ef0991aa24c8f225df10b034f3c2681213cb54cf247623c6dec9a5744e70/mypy-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f3886c03e40afefd327bd70b3f634b39ea82e87f314edaa4d0cce4b927ddcc1", size = 14500739, upload-time = "2026-04-13T02:46:05.442Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/416ebec3047636ed89fa871dc8c54bf05e9e20aa9499da59790d7adb312d/mypy-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e860eb3904f9764e83bafd70c8250bdffdc7dde6b82f486e8156348bf7ceb184", size = 13314735, upload-time = "2026-04-13T02:46:47.154Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1e/1505022d9c9ac2e014a384eb17638fb37bf8e9d0a833ea60605b66f8f7ba/mypy-1.20.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4b5aac6e785719da51a84f5d09e9e843d473170a9045b1ea7ea1af86225df4b", size = 13704356, upload-time = "2026-04-13T02:45:19.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/91/275b01f5eba5c467a3318ec214dd865abb66e9c811231c8587287b92876a/mypy-1.20.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f37b6cd0fe2ad3a20f05ace48ca3523fc52ff86940e34937b439613b6854472e", size = 14696420, upload-time = "2026-04-13T02:45:24.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/57/b3779e134e1b7250d05f874252780d0a88c068bc054bcff99ca20a3a2986/mypy-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4bbb0f6b54ce7cc350ef4a770650d15fa70edd99ad5267e227133eda9c94218", size = 14936093, upload-time = "2026-04-13T02:45:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/be/33/81b64991b0f3f278c3b55c335888794af190b2d59031a5ad1401bcb69f1e/mypy-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3dc20f8ec76eecd77148cdd2f1542ed496e51e185713bf488a414f862deb8f2", size = 10889659, upload-time = "2026-04-13T02:46:02.926Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fd/7adcb8053572edf5ef8f3db59599dfeeee3be9cc4c8c97e2d28f66f42ac5/mypy-1.20.1-cp313-cp313-win_arm64.whl", hash = "sha256:a9d62bbac5d6d46718e2b0330b25e6264463ed832722b8f7d4440ff1be3ca895", size = 9815515, upload-time = "2026-04-13T02:46:32.103Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dc/779abb25a8c63e8f44bf5a336217fa92790fa17e0c40e0c725d10cb01bbd/mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3", size = 11049713, upload-time = "2026-04-13T02:45:57.673Z" },
+    { url = "https://files.pythonhosted.org/packages/28/08/4172be2ad7de9119b5a92ca36abbf641afdc5cb1ef4ae0c3a8182f29674f/mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4", size = 9999819, upload-time = "2026-04-13T02:46:35.039Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/76/e0dee71035316e75a69d73aec2f03c39c21c967b97e277fd0ef8fd6aec66/mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa", size = 12575567, upload-time = "2026-04-13T02:45:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a8/7ed43c9d9c3d1468f86605e323a5d97e411a448790a00f07e779f3211a46/mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08", size = 10378823, upload-time = "2026-04-13T02:45:13.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
 ]
 
 [[package]]
@@ -369,11 +444,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -626,18 +701,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Batch of cleanup commits from the Opus 4.7 audit branch, spanning perf fixes from external feedback, a new generator primitive, and smaller bug fixes / refactors.

### Performance (consumer feedback from a prog-synth user)
- `perf(generate)`: cache `inspect.signature` lookup in `map`/`bind` via `_arity_info` (avoids per-construction introspection in recursive generators)
- `perf(generate)`: cache `bounded_str` cardinality — `str()`/`word()` no longer rebuild a ~10k-entry cardinality sum on every sample

### Features
- `feat(generate)`: add `g.lazy(thunk)` — defers inner generator construction until first sample, memoizes it, reports `c.Infinite()`; breaks eager cardinality blowup in recursive generator trees
- `feat`: expose primary API from `minigun` package root

### Fixes & refactors
- `fix(reporter)`: remove duplicate `execution_start_time` assignment
- `fix`: vary `bounded_str` length across `[lower, upper]`
- `refactor`: clean up strict-mode type annotations
- `test`: silence orchestrator stdout inside nested property test
- `chore(deps)`: drop unused `tqdm`, bump `mypy` to 1.18

## Test plan
- [x] `uv run ruff check minigun/ tests/` passes
- [x] `uv run minigun --time-budget 30 --quiet` passes on the branch
- [ ] CI (ruff format/check, coverage ≥60%, dist build) green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)